### PR TITLE
Remove preStop hook

### DIFF
--- a/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
@@ -42,13 +42,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
         imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - rm -rf /registration/csi-lvm /registration/csi-lvm-reg.sock
         name: node-driver-registrar
         resources: {}
         securityContext:

--- a/tests/files/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
+++ b/tests/files/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
@@ -42,13 +42,6 @@ spec:
               fieldPath: spec.nodeName
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
         imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - rm -rf /registration/csi-lvm /registration/csi-lvm-reg.sock
         name: node-driver-registrar
         resources: {}
         securityContext:


### PR DESCRIPTION
node-driver-registar image is distroless and does not have /bin/sh. The hook always fails.

see also
- https://github.com/kubernetes-csi/csi-driver-host-path/pull/176
- https://github.com/kubernetes-csi/csi-driver-host-path/issues/175