### PR TITLE
Remove type check

### DIFF
--- a/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
@@ -165,7 +165,6 @@ spec:
         name: dev-dir
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: mod-dir
       - hostPath:
           path: /etc/lvm/backup


### PR DESCRIPTION
In some cases the /lib/modules directory is a symlink or slightly different.
This breaks the Directory type check.

Closes #40