### PR TITLE
Bumps versions for k8s-sig images and fixes rbac

### DIFF
--- a/helm/csi-driver-lvm/Chart.yaml
+++ b/helm/csi-driver-lvm/Chart.yaml
@@ -1,7 +1,7 @@
 name: csi-driver-lvm
-version: 0.4.0
+version: 0.4.1
 description: local persistend storage for lvm
-appVersion: v0.4.0
+appVersion: v0.4.1
 apiVersion: v1
 keywords:
 - storage

--- a/helm/csi-driver-lvm/templates/csi-lvm-attacher.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-attacher.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.1
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
+        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
         imagePullPolicy: IfNotPresent
         name: node-driver-registrar
         resources: {}
@@ -128,7 +128,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --health-port=9898
-        image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+        image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources: {}

--- a/helm/csi-driver-lvm/templates/csi-lvm-provisioner.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-provisioner.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/helm/csi-driver-lvm/templates/csi-lvm-resizer.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-resizer.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/helm/csi-driver-lvm/templates/external-attacher-rbac.yaml
+++ b/helm/csi-driver-lvm/templates/external-attacher-rbac.yaml
@@ -26,6 +26,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Support for arm64 was missing due to the use of k8s-sigs images that predated being built cross-platform. The bump in images works on arm64, but only with the additional inclusion of the RBAC change.

This covers create and delete cases for PVCs following the [mytest example](https://github.com/metal-stack/csi-driver-lvm/blob/master/examples/mytest.yaml). Not sure if resize will work; it's possible there's an rbac missing there, too. But if it's anything like the one for the attacher, it's just a missing `.../status` resource.

Might be worth parameterizing the various k8s-sig images? Happy to do it if anyone thinks that'd be useful.