### PR TITLE
feat: add option to disable StorageClass provisioning and add additional annotations

### DIFF
--- a/helm/csi-driver-lvm/templates/csi-storageclass-linear.yaml
+++ b/helm/csi-driver-lvm/templates/csi-storageclass-linear.yaml
@@ -1,7 +1,13 @@
+{{- $storageClass := .Values.storageClasses.linear -}}
+{{ if $storageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.lvm.storageClassStub }}-sc-linear
+{{- if not (empty $storageClass.additionalAnnotations) }}
+  annotations:
+    {{- $storageClass.additionalAnnotations | toYaml | nindent 4 -}}
+{{ end }}
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -11,3 +17,4 @@ volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
   type: "linear"
+{{ end }}

--- a/helm/csi-driver-lvm/templates/csi-storageclass-mirror.yaml
+++ b/helm/csi-driver-lvm/templates/csi-storageclass-mirror.yaml
@@ -1,7 +1,13 @@
+{{- $storageClass := .Values.storageClasses.mirror -}}
+{{ if $storageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.lvm.storageClassStub }}-sc-mirror
+{{- if not (empty $storageClass.additionalAnnotations) }}
+  annotations:
+    {{- $storageClass.additionalAnnotations | toYaml | nindent 4 -}}
+{{ end }}
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -10,4 +16,5 @@ reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
-  type: mirror
+  type: "mirror"
+{{ end }}

--- a/helm/csi-driver-lvm/templates/csi-storageclass-striped.yaml
+++ b/helm/csi-driver-lvm/templates/csi-storageclass-striped.yaml
@@ -1,7 +1,13 @@
+{{- $storageClass := .Values.storageClasses.striped -}}
+{{ if $storageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.lvm.storageClassStub }}-sc-striped
+{{- if not (empty $storageClass.additionalAnnotations) }}
+  annotations:
+    {{- $storageClass.additionalAnnotations | toYaml | nindent 4 -}}
+{{ end }}
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -11,3 +17,4 @@ volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
   type: "striped"
+{{ end }}

--- a/helm/csi-driver-lvm/values.yaml
+++ b/helm/csi-driver-lvm/values.yaml
@@ -24,3 +24,16 @@ rbac:
 
 kubernetes:
   kubeletPath: /var/lib/kubelet
+
+storageClasses:
+  linear:
+    enabled: true
+    additionalAnnotations: []
+    # this might be used to mark one of the StorageClasses as default:
+    # storageclass.kubernetes.io/is-default-class: "true"
+  striped:
+    enabled: true
+    additionalAnnotations: []
+  mirror:
+    enabled: true
+    additionalAnnotations: []


### PR DESCRIPTION
added values flags to disable individual `StorageClass` instances. Also added the option to add annotations to the `StorageClass` instances:

```yaml
storageClasses:
  linear:
    enabled: true
    additionalAnnotations: []
    # this might be used to mark one of the StorageClasses as default:
    # storageclass.kubernetes.io/is-default-class: "true"
  striped:
    enabled: true
    additionalAnnotations: []
  mirror:
    enabled: true
    additionalAnnotations: []
```