### PR TITLE
Add nodeSelection and tolerations

### DIFF
--- a/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
@@ -29,6 +29,10 @@ spec:
         app: csi-lvmplugin
     spec:
       serviceAccountName: csi-lvmplugin
+      {{- if .Values.tolerations.plugin }}
+      tolerations:
+{{ toYaml .Values.tolerations.plugin | indent 8 }}
+      {{- end }}
       containers:
       - args:
         - --v=5

--- a/helm/csi-driver-lvm/templates/csi-lvm-provisioner.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-provisioner.yaml
@@ -32,6 +32,10 @@ spec:
       labels:
         app: csi-lvm-provisioner
     spec:
+      {{- if .Values.nodeSelector.provisioner }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector.provisioner | indent 8 }}
+      {{- end }}
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -42,6 +46,10 @@ spec:
                 values:
                 - csi-lvmplugin
             topologyKey: kubernetes.io/hostname
+      {{- if .Values.tolerations.provisioner }}
+      tolerations:
+{{ toYaml .Values.tolerations.provisioner | indent 8 }}
+      {{- end }}
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner

--- a/helm/csi-driver-lvm/values.yaml
+++ b/helm/csi-driver-lvm/values.yaml
@@ -37,3 +37,29 @@ storageClasses:
   mirror:
     enabled: true
     additionalAnnotations: []
+
+nodeSelector:
+  # The plugin ds will run on all nodes if it has a toleration,
+  # so it is not necessary to set a nodeSelector for it
+
+  # The provisioner has an affinity for nodes with a plugin pod,
+  # but since that's a daemonset, we allow more fine-grained node selection
+  provisioner:
+    # May need to be updated to node-role.kubernetes.io/control-plane
+    node-role.kubernetes.io/master: ""
+
+tolerations:
+  plugin:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  provisioner:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule

--- a/helm/csi-driver-lvm/values.yaml
+++ b/helm/csi-driver-lvm/values.yaml
@@ -39,27 +39,29 @@ storageClasses:
     additionalAnnotations: []
 
 nodeSelector:
-  # The plugin ds will run on all nodes if it has a toleration,
+  # The plugin daemonset will run on all nodes if it has a toleration,
   # so it is not necessary to set a nodeSelector for it
 
   # The provisioner has an affinity for nodes with a plugin pod,
   # but since that's a daemonset, we allow more fine-grained node selection
-  provisioner:
-    # May need to be updated to node-role.kubernetes.io/control-plane
-    node-role.kubernetes.io/master: ""
+
+  #provisioner:
+    #node-role.kubernetes.io/master: ""
+    ## Key name may need to be updated to 'node-role.kubernetes.io/control-plane'
+    ## in the future
 
 tolerations:
-  plugin:
-  - key: node-role.kubernetes.io/master
-    operator: Exists
-    effect: NoSchedule
-  - key: node-role.kubernetes.io/control-plane
-    operator: Exists
-    effect: NoSchedule
-  provisioner:
-  - key: node-role.kubernetes.io/master
-    operator: Exists
-    effect: NoSchedule
-  - key: node-role.kubernetes.io/control-plane
-    operator: Exists
-    effect: NoSchedule
+  #plugin:
+  #- key: node-role.kubernetes.io/master
+  #  operator: Exists
+  #  effect: NoSchedule
+  #- key: node-role.kubernetes.io/control-plane
+  #  operator: Exists
+  #  effect: NoSchedule
+  #provisioner:
+  #- key: node-role.kubernetes.io/master
+  #  operator: Exists
+  #  effect: NoSchedule
+  #- key: node-role.kubernetes.io/control-plane
+  #  operator: Exists
+  #  effect: NoSchedule


### PR DESCRIPTION
This commit adds a nodeSelector for the provisioner, and tolerations for the plugin and the provisioner. These are both configurable in the Helm values. ~~The current behavior defaults to tolerating and having an affinity for the master node.~~

_Edit: The current behavior has the nodeSelector and tolerations commented out in order to preserve the same / expected behavior for an upgrade from a release without this change to a release with this change._