### PR TITLE
Allow overriding of k8s-sigs images through helm

### DIFF
--- a/helm/csi-driver-lvm/templates/csi-lvm-attacher.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-attacher.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.1
+          image: {{ .Values.attacher.image }}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
+        image: {{ .Values.register.image }}
         imagePullPolicy: IfNotPresent
         name: node-driver-registrar
         resources: {}
@@ -128,7 +128,7 @@ spec:
       - args:
         - --csi-address=/csi/csi.sock
         - --health-port=9898
-        image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+        image: {{ .Values.livenessprobe.image }}
         imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources: {}

--- a/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-plugin-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: {{ .Values.register.image }}
+        image: {{ .Values.registrar.image }}
         imagePullPolicy: IfNotPresent
         name: node-driver-registrar
         resources: {}

--- a/helm/csi-driver-lvm/templates/csi-lvm-provisioner.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-provisioner.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1
+          image: {{ .Values.provisioner.image }}
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/helm/csi-driver-lvm/templates/csi-lvm-resizer.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-resizer.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
+          image: {{ .Values.resizer.image }}
           args:
             - -v=5
             - -csi-address=/csi/csi.sock

--- a/helm/csi-driver-lvm/values.yaml
+++ b/helm/csi-driver-lvm/values.yaml
@@ -28,7 +28,7 @@ kubernetes:
 attacher:
   image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.1
 
-liveness-probe:
+livenessprobe:
   image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
 
 provisioner:

--- a/helm/csi-driver-lvm/values.yaml
+++ b/helm/csi-driver-lvm/values.yaml
@@ -25,6 +25,21 @@ rbac:
 kubernetes:
   kubeletPath: /var/lib/kubelet
 
+attacher:
+  image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.1
+
+liveness-probe:
+  image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+
+provisioner:
+  image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1
+
+registrar:
+  image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
+
+resizer:
+  image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
+
 storageClasses:
   linear:
     enabled: true


### PR DESCRIPTION
Similar to other csi, enable overriding k8s sig images through helm. This allow using other images and not being locked to k8s sig ones.

The change set current default values in `values.yaml`, but allow passing an override for each during helm install. 