### PR TITLE
Support K8s v1.22

### DIFF
--- a/helm/csi-driver-lvm/templates/csi-lvm-driverinfo.yaml
+++ b/helm/csi-driver-lvm/templates/csi-lvm-driverinfo.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: {{ .Values.lvm.driverName }}

--- a/helm/csi-driver-lvm/templates/external-attacher-rbac.yaml
+++ b/helm/csi-driver-lvm/templates/external-attacher-rbac.yaml
@@ -26,6 +26,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/csi-driver-lvm/templates/external-resizer-rbac.yaml
+++ b/helm/csi-driver-lvm/templates/external-resizer-rbac.yaml
@@ -29,6 +29,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/helm/csi-driver-lvm/templates/psp.yaml
+++ b/helm/csi-driver-lvm/templates/psp.yaml
@@ -38,7 +38,7 @@ rules:
   verbs:
   - use
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: psp-rolebinding-lvm

--- a/helm/csi-driver-lvm/values.yaml
+++ b/helm/csi-driver-lvm/values.yaml
@@ -26,19 +26,19 @@ kubernetes:
   kubeletPath: /var/lib/kubelet
 
 attacher:
-  image: k8s.gcr.io/sig-storage/csi-attacher:v2.2.1
+  image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
 
 livenessprobe:
-  image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
+  image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
 
 provisioner:
-  image: k8s.gcr.io/sig-storage/csi-provisioner:v1.6.1
+  image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
 
 registrar:
-  image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v1.3.0
+  image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
 
 resizer:
-  image: k8s.gcr.io/sig-storage/csi-resizer:v0.5.0
+  image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
 
 storageClasses:
   linear:


### PR DESCRIPTION
This PR fixes the usage of right APIs (`v1` VS `v1beta1`) and bumps versions of k8s.gcr.io/sig-storage images. This is necessary in order to work on k8s version 1.22.