### PR TITLE
Add image pull secret support

### DIFF
--- a/cmd/lvmplugin/main.go
+++ b/cmd/lvmplugin/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,6 +46,7 @@ var (
 	namespace         = flag.String("namespace", "csi-lvm", "name of namespace")
 	provisionerImage  = flag.String("provisionerimage", "metalstack/csi-lvmplugin-provisioner", "name of provisioner image")
 	pullPolicy        = flag.String("pullpolicy", "ifnotpresent", "pull policy for provisioner image")
+	imagePullSecret   = flag.String("imagepullsecret", "", "name of image pull secret for provisioner pods")
 
 	// Set by the build process
 	version = ""
@@ -69,7 +70,7 @@ func main() {
 }
 
 func handle() {
-	driver, err := lvm.NewLvmDriver(*driverName, *nodeID, *endpoint, *hostWritePath, *ephemeral, *maxVolumesPerNode, version, *devicesPattern, *vgName, *namespace, *provisionerImage, *pullPolicy)
+	driver, err := lvm.NewLvmDriver(*driverName, *nodeID, *endpoint, *hostWritePath, *ephemeral, *maxVolumesPerNode, version, *devicesPattern, *vgName, *namespace, *provisionerImage, *pullPolicy, *imagePullSecret)
 	if err != nil {
 		fmt.Printf("Failed to initialize driver: %s\n", err.Error())
 		os.Exit(1)

--- a/pkg/lvm/lvm.go
+++ b/pkg/lvm/lvm.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -54,9 +54,10 @@ type Lvm struct {
 	pullPolicy        v1.PullPolicy
 	namespace         string
 
-	ids *identityServer
-	ns  *nodeServer
-	cs  *controllerServer
+	ids             *identityServer
+	ns              *nodeServer
+	cs              *controllerServer
+	imagePullSecret string
 }
 
 var (
@@ -79,6 +80,7 @@ type volumeAction struct {
 	vgName           string
 	hostWritePath    string
 	integrity        bool
+	imagePullSecret  string
 }
 
 const (
@@ -96,7 +98,7 @@ var (
 )
 
 // NewLvmDriver creates the driver
-func NewLvmDriver(driverName, nodeID, endpoint string, hostWritePath string, ephemeral bool, maxVolumesPerNode int64, version string, devicesPattern string, vgName string, namespace string, provisionerImage string, pullPolicy string) (*Lvm, error) {
+func NewLvmDriver(driverName, nodeID, endpoint string, hostWritePath string, ephemeral bool, maxVolumesPerNode int64, version string, devicesPattern string, vgName string, namespace string, provisionerImage string, pullPolicy string, imagePullSecret string) (*Lvm, error) {
 	if driverName == "" {
 		return nil, fmt.Errorf("no driver name provided")
 	}
@@ -134,6 +136,7 @@ func NewLvmDriver(driverName, nodeID, endpoint string, hostWritePath string, eph
 		namespace:         namespace,
 		provisionerImage:  provisionerImage,
 		pullPolicy:        pp,
+		imagePullSecret:   imagePullSecret,
 	}, nil
 }
 
@@ -143,7 +146,7 @@ func (lvm *Lvm) Run() error {
 	// Create GRPC servers
 	lvm.ids = newIdentityServer(lvm.name, lvm.version)
 	lvm.ns = newNodeServer(lvm.nodeID, lvm.ephemeral, lvm.maxVolumesPerNode, lvm.devicesPattern, lvm.vgName)
-	lvm.cs, err = newControllerServer(lvm.ephemeral, lvm.nodeID, lvm.devicesPattern, lvm.vgName, lvm.hostWritePath, lvm.namespace, lvm.provisionerImage, lvm.pullPolicy)
+	lvm.cs, err = newControllerServer(lvm.ephemeral, lvm.nodeID, lvm.devicesPattern, lvm.vgName, lvm.hostWritePath, lvm.namespace, lvm.provisionerImage, lvm.pullPolicy, lvm.imagePullSecret)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
PR adds support to specify an image pull secret for the provisioner pods created by the CSI LVM driver. The new --imagepullsecret flag can be set via CLI
