### PR TITLE
Support specifying stripe size and MKFS options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ Now you can use one of following storageClasses:
 
 To get the previous old and now deprecated `csi-lvm-sc-linear`, ... storageclasses, set helm-chart value `compat03x=true`.
 
+## Stripe size ##
+
+For `striped` volumes you can optionally set the LVM stripe size via the `stripeSize` parameter on the StorageClass. The value is passed verbatim to `lvcreate --stripesize` and must be a power of two (e.g. `64k`, `256k`, `1m`). It applies to `striped` volumes only, and only when the node's volume group has at least two physical volumes; otherwise it is ignored.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-lvm-sc-striped-stripesize
+provisioner: lvm.csi.metal-stack.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: "striped"
+  stripeSize: "64k"
+```
+
 ## Encryption ##
 
 csi-driver-lvm supports LUKS2 encryption for volumes at rest. When encryption is enabled, the LVM logical volume is formatted with LUKS2 and a dm-crypt mapper device is used transparently for all I/O.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ parameters:
   stripeSize: "64k"
 ```
 
+## mkfs options ##
+
+You can pass extra options to the `mkfs` call that formats a volume via the `mkfsOptions` parameter on the StorageClass. The value is split on whitespace and passed verbatim to `mkfs.<fsType>` before the device argument, so the accepted options depend on the filesystem (`fsType`). The options only take effect when the volume is first formatted; they are ignored for an already-formatted volume.
+
+This pairs well with striped volumes (see *Stripe size* above): for `ext4` you can align the filesystem to the LVM stripe geometry via `stride`/`stripe_width`.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-lvm-sc-striped-mkfsoptions
+provisioner: lvm.csi.metal-stack.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: "striped"
+  mkfsOptions: "-E stride=64,stripe_width=384"
+```
+
 ## Encryption ##
 
 csi-driver-lvm supports LUKS2 encryption for volumes at rest. When encryption is enabled, the LVM logical volume is formatted with LUKS2 and a dm-crypt mapper device is used transparently for all I/O.

--- a/examples/csi-storageclass-striped-mkfsoptions.yaml
+++ b/examples/csi-storageclass-striped-mkfsoptions.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-lvm-sc-striped-mkfsoptions
+provisioner: lvm.csi.metal-stack.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: "striped"
+  # Optional: extra options for the "mkfs" call that formats the volume. The value is
+  # split on whitespace and passed verbatim to "mkfs.<fsType>" before the device, so
+  # the accepted options depend on the filesystem. Here ext4's stride/stripe_width are
+  # aligned to a striped LV. Only applied when the volume is first formatted.
+  mkfsOptions: "-E stride=64,stripe_width=384"

--- a/examples/csi-storageclass-striped-stripesize.yaml
+++ b/examples/csi-storageclass-striped-stripesize.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-lvm-sc-striped-stripesize
+provisioner: lvm.csi.metal-stack.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: "striped"
+  # Optional: LVM stripe size, passed verbatim to "lvcreate --stripesize".
+  # Must be a power of two (e.g. "64k", "256k", "1m"). Applies to striped volumes
+  # only, and only when the node's volume group has at least two physical volumes;
+  # otherwise it is ignored.
+  stripeSize: "64k"

--- a/pkg/lvm/lvm.go
+++ b/pkg/lvm/lvm.go
@@ -32,7 +32,7 @@ type lsblk struct {
 	} `json:"blockdevices"`
 }
 
-func MountLV(log *slog.Logger, lvname, mountPath, fsType, devicePath string, mountOptions []string) (string, error) {
+func MountLV(log *slog.Logger, lvname, mountPath, fsType, devicePath string, mountOptions []string, mkfsOptions string) (string, error) {
 	lvPath := devicePath
 
 	formatted := false
@@ -71,11 +71,7 @@ func MountLV(log *slog.Logger, lvname, mountPath, fsType, devicePath string, mou
 	}
 
 	if !formatted {
-		formatArgs := []string{}
-		if forceFormat {
-			formatArgs = append(formatArgs, "-f")
-		}
-		formatArgs = append(formatArgs, lvPath)
+		formatArgs := buildMkfsArgs(lvPath, forceFormat, mkfsOptions)
 
 		log.Debug("formatting with mkfs", "fs-type", fsType, "args", strings.Join(formatArgs, " "))
 		cmd = exec.Command(fmt.Sprintf("mkfs.%s", fsType), formatArgs...) //nolint:gosec
@@ -111,6 +107,21 @@ func MountLV(log *slog.Logger, lvname, mountPath, fsType, devicePath string, mou
 	}
 	log.Debug("mountlv output", "output", out)
 	return "", nil
+}
+
+// buildMkfsArgs assembles the mkfs command-line arguments, with the device path
+// appended last.
+// mkfsOptions, when set, is split on whitespace and passed verbatim before
+// the device path (e.g. "-E stride=64,stripe_width=384" to align an ext4
+// filesystem to a striped LV). The accepted options depend on the filesystem.
+func buildMkfsArgs(devicePath string, forceFormat bool, mkfsOptions string) []string {
+	args := []string{}
+	if forceFormat {
+		args = append(args, "-f")
+	}
+	args = append(args, strings.Fields(mkfsOptions)...)
+	args = append(args, devicePath)
+	return args
 }
 
 func BindMountLV(log *slog.Logger, lvname, mountPath string, devicePath string) (string, error) {

--- a/pkg/lvm/lvm.go
+++ b/pkg/lvm/lvm.go
@@ -250,9 +250,9 @@ func CreateVG(log *slog.Logger, name string, devicesPattern string) (string, err
 	return string(out), err
 }
 
-// CreateLV creates the new volume
-// used by lvcreate provisioner pod and by nodeserver for ephemeral volumes
-func CreateLV(log *slog.Logger, vg string, name string, size uint64, lvmType string, integrity bool) (string, error) {
+// CreateLV creates the new volume.
+// Used by the controller's CreateVolume and by the nodeserver for ephemeral volumes.
+func CreateLV(log *slog.Logger, vg string, name string, size uint64, lvmType string, integrity bool, stripeSize string) (string, error) {
 	if LvExists(log, vg, name) {
 		log.Debug("logicalvolume already exists", "name", name)
 		return name, nil
@@ -263,13 +263,11 @@ func CreateLV(log *slog.Logger, vg string, name string, size uint64, lvmType str
 	}
 
 	switch lvmType {
-	case "linear", "mirror", "striped":
+	case linearType, mirrorType, stripedType:
 		// These are supported lvm types
 	default:
 		return "", fmt.Errorf("lvmType is incorrect: %s", lvmType)
 	}
-
-	args := []string{"-v", "--yes", "-n", name, "-W", "y", "-L", fmt.Sprintf("%db", size)}
 
 	pvs, err := pvCount(vg)
 	if err != nil {
@@ -278,17 +276,42 @@ func CreateLV(log *slog.Logger, vg string, name string, size uint64, lvmType str
 
 	if pvs < 2 {
 		log.Warn("pvcount is <2 only linear is supported")
+	}
+
+	args, err := buildLvcreateArgs(name, size, lvmType, pvs, integrity, stripeSize)
+	if err != nil {
+		return "", err
+	}
+
+	args = append(args, vg)
+	log.Debug("lvcreate", "args", args)
+	cmd := exec.Command("lvcreate", args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// buildLvcreateArgs assembles the lvcreate command-line arguments, excluding the
+// volume group name which the caller appends last.
+// stripeSize, when set, is passed verbatim to lvcreate's --stripesize (e.g. "256k")
+// and only applies to striped volumes.
+func buildLvcreateArgs(name string, size uint64, lvmType string, pvs int, integrity bool, stripeSize string) ([]string, error) {
+	args := []string{"-v", "--yes", "-n", name, "-W", "y", "-L", fmt.Sprintf("%db", size)}
+
+	if pvs < 2 {
 		lvmType = linearType
 	}
 
 	switch lvmType {
 	case stripedType:
 		args = append(args, "--type", "striped", "--stripes", fmt.Sprintf("%d", pvs))
+		if s := strings.TrimSpace(stripeSize); s != "" {
+			args = append(args, "--stripesize", s)
+		}
 	case mirrorType:
 		args = append(args, "--type", "raid1", "--mirrors", "1", "--nosync")
 	case linearType:
 	default:
-		return "", fmt.Errorf("unsupported lvmtype: %s", lvmType)
+		return nil, fmt.Errorf("unsupported lvmtype: %s", lvmType)
 	}
 
 	if integrity {
@@ -296,7 +319,7 @@ func CreateLV(log *slog.Logger, vg string, name string, size uint64, lvmType str
 		case mirrorType:
 			args = append(args, "--raidintegrity", "y")
 		default:
-			return "", fmt.Errorf("integrity is only supported if type is mirror")
+			return nil, fmt.Errorf("integrity is only supported if type is mirror")
 		}
 	}
 
@@ -304,11 +327,8 @@ func CreateLV(log *slog.Logger, vg string, name string, size uint64, lvmType str
 	for _, tag := range tags {
 		args = append(args, "--addtag", tag)
 	}
-	args = append(args, vg)
-	log.Debug("lvcreate", "args", args)
-	cmd := exec.Command("lvcreate", args...)
-	out, err := cmd.CombinedOutput()
-	return string(out), err
+
+	return args, nil
 }
 
 func LvExists(log *slog.Logger, vg string, name string) bool {

--- a/pkg/lvm/lvm_test.go
+++ b/pkg/lvm/lvm_test.go
@@ -147,3 +147,101 @@ func TestBuildLvcreateArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildMkfsArgs(t *testing.T) {
+	const device = "/dev/csi-lvm/pvc-123"
+
+	tests := []struct {
+		name        string
+		forceFormat bool
+		mkfsOptions string
+		check       func(t *testing.T, args []string)
+	}{
+		{
+			name: "no options is just the device path",
+			check: func(t *testing.T, args []string) {
+				if len(args) != 1 {
+					t.Errorf("expected only the device path, got %v", args)
+				}
+				if hasFlag(args, "-f") {
+					t.Errorf("did not expect -f, got %v", args)
+				}
+			},
+		},
+		{
+			name:        "force only",
+			forceFormat: true,
+			check: func(t *testing.T, args []string) {
+				if args[0] != "-f" {
+					t.Errorf("expected -f first, got %v", args)
+				}
+				if len(args) != 2 {
+					t.Errorf("expected -f and the device path only, got %v", args)
+				}
+			},
+		},
+		{
+			name:        "mkfs options only",
+			mkfsOptions: "-E stride=64,stripe_width=384",
+			check: func(t *testing.T, args []string) {
+				if hasFlag(args, "-f") {
+					t.Errorf("did not expect -f, got %v", args)
+				}
+				if !hasFlagValue(args, "-E", "stride=64,stripe_width=384") {
+					t.Errorf("expected -E stride=64,stripe_width=384, got %v", args)
+				}
+			},
+		},
+		{
+			name:        "force and mkfs options",
+			forceFormat: true,
+			mkfsOptions: "-E stride=64,stripe_width=384",
+			check: func(t *testing.T, args []string) {
+				if args[0] != "-f" {
+					t.Errorf("expected -f first, got %v", args)
+				}
+				if !hasFlagValue(args, "-E", "stride=64,stripe_width=384") {
+					t.Errorf("expected -E stride=64,stripe_width=384, got %v", args)
+				}
+			},
+		},
+		{
+			name:        "surrounding and repeated whitespace is collapsed",
+			mkfsOptions: "  -b 4096   -E stride=64  ",
+			check: func(t *testing.T, args []string) {
+				if !hasFlagValue(args, "-b", "4096") {
+					t.Errorf("expected -b 4096, got %v", args)
+				}
+				if !hasFlagValue(args, "-E", "stride=64") {
+					t.Errorf("expected -E stride=64, got %v", args)
+				}
+				for _, a := range args {
+					if a == "" {
+						t.Errorf("did not expect an empty argument, got %v", args)
+					}
+				}
+			},
+		},
+		{
+			name:        "whitespace-only options are ignored",
+			mkfsOptions: "   ",
+			check: func(t *testing.T, args []string) {
+				if len(args) != 1 {
+					t.Errorf("expected only the device path, got %v", args)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := buildMkfsArgs(device, tt.forceFormat, tt.mkfsOptions)
+			if len(args) == 0 || args[len(args)-1] != device {
+				t.Fatalf("expected the device path %q to be the last argument, got %v", device, args)
+			}
+			if tt.check != nil {
+				tt.check(t, args)
+			}
+		})
+	}
+}

--- a/pkg/lvm/lvm_test.go
+++ b/pkg/lvm/lvm_test.go
@@ -1,0 +1,149 @@
+package lvm
+
+import "testing"
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFlagValue(args []string, flag, value string) bool {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildLvcreateArgs(t *testing.T) {
+	const (
+		name = "pvc-123"
+		size = uint64(104857600) // 100Mi
+	)
+
+	tests := []struct {
+		name       string
+		lvmType    string
+		pvs        int
+		integrity  bool
+		stripeSize string
+		wantErr    bool
+		check      func(t *testing.T, args []string)
+	}{
+		{
+			name:       "striped with stripe size",
+			lvmType:    stripedType,
+			pvs:        2,
+			stripeSize: "64k",
+			check: func(t *testing.T, args []string) {
+				if !hasFlagValue(args, "--type", "striped") {
+					t.Errorf("expected --type striped, got %v", args)
+				}
+				if !hasFlagValue(args, "--stripes", "2") {
+					t.Errorf("expected --stripes 2, got %v", args)
+				}
+				if !hasFlagValue(args, "--stripesize", "64k") {
+					t.Errorf("expected --stripesize 64k, got %v", args)
+				}
+			},
+		},
+		{
+			name:    "striped without stripe size",
+			lvmType: stripedType,
+			pvs:     2,
+			check: func(t *testing.T, args []string) {
+				if !hasFlagValue(args, "--type", "striped") {
+					t.Errorf("expected --type striped, got %v", args)
+				}
+				if hasFlag(args, "--stripesize") {
+					t.Errorf("did not expect --stripesize, got %v", args)
+				}
+			},
+		},
+		{
+			name:       "striped stripe size is trimmed",
+			lvmType:    stripedType,
+			pvs:        3,
+			stripeSize: "  256k  ",
+			check: func(t *testing.T, args []string) {
+				if !hasFlagValue(args, "--stripesize", "256k") {
+					t.Errorf("expected trimmed --stripesize 256k, got %v", args)
+				}
+			},
+		},
+		{
+			name:       "striped falls back to linear with a single pv",
+			lvmType:    stripedType,
+			pvs:        1,
+			stripeSize: "64k",
+			check: func(t *testing.T, args []string) {
+				if hasFlag(args, "--type") {
+					t.Errorf("did not expect --type for linear fallback, got %v", args)
+				}
+				if hasFlag(args, "--stripes") {
+					t.Errorf("did not expect --stripes for linear fallback, got %v", args)
+				}
+				if hasFlag(args, "--stripesize") {
+					t.Errorf("did not expect --stripesize for linear fallback, got %v", args)
+				}
+			},
+		},
+		{
+			name:       "stripe size ignored for linear",
+			lvmType:    linearType,
+			pvs:        2,
+			stripeSize: "64k",
+			check: func(t *testing.T, args []string) {
+				if hasFlag(args, "--stripesize") {
+					t.Errorf("did not expect --stripesize for linear, got %v", args)
+				}
+			},
+		},
+		{
+			name:       "stripe size ignored for mirror",
+			lvmType:    mirrorType,
+			pvs:        2,
+			stripeSize: "64k",
+			check: func(t *testing.T, args []string) {
+				if !hasFlagValue(args, "--type", "raid1") {
+					t.Errorf("expected --type raid1, got %v", args)
+				}
+				if hasFlag(args, "--stripesize") {
+					t.Errorf("did not expect --stripesize for mirror, got %v", args)
+				}
+			},
+		},
+		{
+			name:    "unsupported type errors",
+			lvmType: "bogus",
+			pvs:     2,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, err := buildLvcreateArgs(name, size, tt.lvmType, tt.pvs, tt.integrity, tt.stripeSize)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil (args %v)", args)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !hasFlagValue(args, "-n", name) {
+				t.Errorf("expected -n %s, got %v", name, args)
+			}
+			if tt.check != nil {
+				tt.check(t, args)
+			}
+		})
+	}
+}

--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -50,6 +50,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Errorf(codes.Internal, "lvmType is incorrect: %s", lvmType)
 	}
 
+	// stripeSize is passed verbatim to "lvcreate --stripesize" and only takes effect
+	// for striped volumes (see lvm.CreateLV).
+	stripeSize := req.GetParameters()["stripeSize"]
+
 	if value, ok := req.GetParameters()["integrity"]; ok {
 		var err error
 		integrity, err = strconv.ParseBool(value)
@@ -62,7 +66,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	requiredBytes := req.GetCapacityRange().GetRequiredBytes()
 
-	_, err := lvm.CreateLV(d.log, d.vgName, req.GetName(), uint64(requiredBytes), lvmType, integrity)
+	_, err := lvm.CreateLV(d.log, d.vgName, req.GetName(), uint64(requiredBytes), lvmType, integrity, stripeSize)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create lv %s: %w", req.GetName(), err)
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -133,7 +133,8 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	} else if req.GetVolumeCapability().GetMount() != nil {
 		mountCap := req.GetVolumeCapability().GetMount()
-		output, err := lvm.MountLV(d.log, volID, targetPath, mountCap.GetFsType(), devicePath, mountCap.GetMountFlags())
+		mkfsOptions := req.GetVolumeContext()["mkfsOptions"]
+		output, err := lvm.MountLV(d.log, volID, targetPath, mountCap.GetFsType(), devicePath, mountCap.GetMountFlags(), mkfsOptions)
 		if err != nil {
 			return nil, fmt.Errorf("unable to mount lv: %w output:%s", err, output)
 		}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -73,7 +73,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 			return nil, fmt.Errorf("unable to create vg: %w output:%s", err, output)
 		}
 
-		output, err = lvm.CreateLV(d.log, d.vgName, volID, size, req.GetVolumeContext()["type"], false)
+		output, err = lvm.CreateLV(d.log, d.vgName, volID, size, req.GetVolumeContext()["type"], false, req.GetVolumeContext()["stripeSize"])
 		if err != nil {
 			return nil, fmt.Errorf("unable to create lv: %w output:%s", err, output)
 		}

--- a/tests/bats/test.bats
+++ b/tests/bats/test.bats
@@ -368,6 +368,58 @@
     [ "$status" -eq 0 ]
 }
 
+@test "create storageclass with stripeSize" {
+    run kubectl apply -f files/storageclass.stripesize.yaml --wait --timeout=10s
+    [ "$status" -eq 0 ]
+}
+
+@test "create pvc with stripeSize storageclass" {
+    run kubectl apply -f files/pvc.stripesize.yaml --wait --timeout=30s
+    [ "$status" -eq 0 ]
+
+    run kubectl wait --for=jsonpath='{.status.phase}'=Pending -f files/pvc.stripesize.yaml --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "deploy stripeSize pod" {
+    run kubectl apply -f files/pod.stripesize.vol.yaml --wait --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "stripeSize pod running" {
+    run kubectl wait --for=jsonpath='{.status.phase}'=Running -f files/pod.stripesize.vol.yaml --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "check stripeSize applied to logical volume" {
+    PV_NAME=$(kubectl get pvc lvm-pvc-stripesize -o jsonpath='{.spec.volumeName}')
+    [ -n "$PV_NAME" ]
+    NODE=$(kubectl get pod volume-test-stripesize -o jsonpath='{.spec.nodeName}')
+    PLUGIN_POD=$(kubectl get pods -n csi-driver-lvm -l app=csi-driver-lvm --field-selector "spec.nodeName=$NODE" -o jsonpath='{.items[0].metadata.name}')
+
+    # A linear volume reports a stripe size of 0; 256k (262144 bytes) proves the LV
+    # was striped via our "lvcreate --stripesize 256k" (LVM's default is 64k).
+    # Note: the lvs report field is "stripe_size", not the "--stripesize" option name.
+    run kubectl exec -n csi-driver-lvm "$PLUGIN_POD" -c csi-driver-lvm -- lvs --noheadings --nosuffix --units b -o stripe_size "csi-lvm/$PV_NAME"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"262144"* ]]
+}
+
+@test "delete stripeSize pod" {
+    run kubectl delete -f files/pod.stripesize.vol.yaml --grace-period=0 --wait --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "delete stripeSize pvc" {
+    run kubectl delete -f files/pvc.stripesize.yaml --grace-period=0 --wait --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "delete stripeSize storageclass" {
+    run kubectl delete -f files/storageclass.stripesize.yaml --wait --timeout=10s
+    [ "$status" -eq 0 ]
+}
+
 @test "write to volume and ensure data gets written" {
     run kubectl apply -f files/pvc.remount.yaml --wait --timeout=30s
     [ "$status" -eq 0 ]

--- a/tests/bats/test.bats
+++ b/tests/bats/test.bats
@@ -420,6 +420,62 @@
     [ "$status" -eq 0 ]
 }
 
+@test "create storageclass with mkfsOptions" {
+    run kubectl apply -f files/storageclass.mkfsoptions.yaml --wait --timeout=10s
+    [ "$status" -eq 0 ]
+}
+
+@test "create pvc with mkfsOptions storageclass" {
+    run kubectl apply -f files/pvc.mkfsoptions.yaml --wait --timeout=30s
+    [ "$status" -eq 0 ]
+
+    run kubectl wait --for=jsonpath='{.status.phase}'=Pending -f files/pvc.mkfsoptions.yaml --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "deploy mkfsOptions pod" {
+    run kubectl apply -f files/pod.mkfsoptions.vol.yaml --wait --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "mkfsOptions pod running" {
+    run kubectl wait --for=jsonpath='{.status.phase}'=Running -f files/pod.mkfsoptions.vol.yaml --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "check mkfsOptions applied to filesystem" {
+    PV_NAME=$(kubectl get pvc lvm-pvc-mkfsoptions -o jsonpath='{.spec.volumeName}')
+    [ -n "$PV_NAME" ]
+    NODE=$(kubectl get pod volume-test-mkfsoptions -o jsonpath='{.spec.nodeName}')
+    PLUGIN_POD=$(kubectl get pods -n csi-driver-lvm -l app=csi-driver-lvm --field-selector "spec.nodeName=$NODE" -o jsonpath='{.items[0].metadata.name}')
+
+    # ext4 was formatted with "-E stride=64,stripe_width=384"; tune2fs echoes those
+    # back as the "RAID stride" / "RAID stripe width" superblock fields. A linear LV
+    # has no auto-detected geometry, so seeing them proves the option reached mkfs.
+    run kubectl exec -n csi-driver-lvm "$PLUGIN_POD" -c csi-driver-lvm -- sh -c "tune2fs -l /dev/csi-lvm/$PV_NAME 2>/dev/null | grep 'RAID stride'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"64"* ]]
+
+    run kubectl exec -n csi-driver-lvm "$PLUGIN_POD" -c csi-driver-lvm -- sh -c "tune2fs -l /dev/csi-lvm/$PV_NAME 2>/dev/null | grep 'RAID stripe width'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"384"* ]]
+}
+
+@test "delete mkfsOptions pod" {
+    run kubectl delete -f files/pod.mkfsoptions.vol.yaml --grace-period=0 --wait --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "delete mkfsOptions pvc" {
+    run kubectl delete -f files/pvc.mkfsoptions.yaml --grace-period=0 --wait --timeout=30s
+    [ "$status" -eq 0 ]
+}
+
+@test "delete mkfsOptions storageclass" {
+    run kubectl delete -f files/storageclass.mkfsoptions.yaml --wait --timeout=10s
+    [ "$status" -eq 0 ]
+}
+
 @test "write to volume and ensure data gets written" {
     run kubectl apply -f files/pvc.remount.yaml --wait --timeout=30s
     [ "$status" -eq 0 ]

--- a/tests/files/pod.mkfsoptions.vol.yaml
+++ b/tests/files/pod.mkfsoptions.vol.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test-mkfsoptions
+spec:
+  containers:
+  - name: volume-test
+    image: alpine
+    imagePullPolicy: IfNotPresent
+    command:
+      - tail
+      - -f
+      - /etc/hosts
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 10014
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+    volumeMounts:
+    - name: data
+      mountPath: /data
+    resources:
+      limits:
+        cpu: 100m
+        memory: 100M
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: lvm-pvc-mkfsoptions

--- a/tests/files/pod.stripesize.vol.yaml
+++ b/tests/files/pod.stripesize.vol.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test-stripesize
+spec:
+  containers:
+  - name: volume-test
+    image: alpine
+    imagePullPolicy: IfNotPresent
+    command:
+      - tail
+      - -f
+      - /etc/hosts
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 10014
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+    volumeMounts:
+    - name: data
+      mountPath: /data
+    resources:
+      limits:
+        cpu: 100m
+        memory: 100M
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: lvm-pvc-stripesize

--- a/tests/files/pvc.mkfsoptions.yaml
+++ b/tests/files/pvc.mkfsoptions.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lvm-pvc-mkfsoptions
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: csi-driver-lvm-mkfsoptions
+  resources:
+    requests:
+      storage: 100Mi

--- a/tests/files/pvc.stripesize.yaml
+++ b/tests/files/pvc.stripesize.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lvm-pvc-stripesize
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: csi-driver-lvm-stripesize
+  resources:
+    requests:
+      storage: 100Mi

--- a/tests/files/storageclass.mkfsoptions.yaml
+++ b/tests/files/storageclass.mkfsoptions.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-driver-lvm-mkfsoptions
+parameters:
+  type: linear
+  # Passed verbatim to "mkfs.ext4". A linear LV exposes no stripe topology, so
+  # ext4 would not set these on its own — seeing them proves the option took effect.
+  mkfsOptions: "-E stride=64,stripe_width=384"
+provisioner: lvm.csi.metal-stack.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/tests/files/storageclass.stripesize.yaml
+++ b/tests/files/storageclass.stripesize.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-driver-lvm-stripesize
+parameters:
+  type: striped
+  # 256k is deliberately not LVM's 64k default, so the test can tell the
+  # parameter actually reached "lvcreate --stripesize".
+  stripeSize: "256k"
+provisioner: lvm.csi.metal-stack.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
## Description

* Support specifying stripe size, instead of relying on LVM default. This gives us the ability to have different storage classes with different stripe sizes.
* Support specifying MKFS options.

